### PR TITLE
Change visibility of EguiLogger to public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,6 @@ regex = "1.10"
 
 [dev-dependencies]
 eframe = "0.25"
+multi_log = "0.1.2"
+env_logger = "0.10.1"
 

--- a/examples/multi_log.rs
+++ b/examples/multi_log.rs
@@ -1,0 +1,44 @@
+use eframe::NativeOptions;
+
+fn main() {
+    // Create an EguiLogger; multi_log will take care of initialization.
+    let egui_logger = Box::new(egui_logger::EguiLogger);
+
+    // And add another one.
+    let env_logger = Box::new(env_logger::builder().default_format().build());
+
+    multi_log::MultiLogger::init(vec![egui_logger, env_logger], log::Level::Debug)
+        .expect("Error initializing multi_logger");
+
+    eframe::run_native(
+        "egui_logger",
+        NativeOptions::default(),
+        Box::new(|_cc| Box::new(MultiLogApp::default())),
+    )
+    .expect("Couldn't run eframe app");
+}
+
+#[derive(Default)]
+struct MultiLogApp;
+
+impl eframe::App for MultiLogApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            if ui.button("This produces Debug Info").clicked() {
+                log::debug!("Very verbose Debug Info")
+            }
+            if ui.button("This produces an Info").clicked() {
+                log::info!("Some Info");
+            }
+            if ui.button("This produces an Error").clicked() {
+                log::error!("Error doing Something");
+            }
+            if ui.button("This produces a Warning").clicked() {
+                log::warn!("Warn about something")
+            }
+        });
+        egui::Window::new("Log").show(ctx, |ui| {
+            egui_logger::logger_ui(ui);
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ const LEVELS: [log::Level; log::Level::Trace as usize] = [
     log::Level::Trace,
 ];
 
-struct EguiLogger;
+pub struct EguiLogger;
 
 impl log::Log for EguiLogger {
     fn enabled(&self, metadata: &log::Metadata) -> bool {


### PR DESCRIPTION
This way it can be used with other crates such as [multi_log](https://github.com/davechallis/multi_log) (#13). Also adds a simple example for usage with multi_log and env_logger.