### PR TITLE
update egui to 0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ puffin = ["dep:puffin"]
 
 [dependencies]
 log = "0.4"
-egui = "0.32"
+egui = "0.33"
 regex = "1.11"
 puffin = { version = "0.19",  optional = true }
 
 [dev-dependencies]
-eframe = "0.32"
+eframe = "0.33"
 multi_log = "0.1"
 env_logger = "0.11"
 puffin_egui = { version = "0.29.0" }

--- a/examples/puffin.rs
+++ b/examples/puffin.rs
@@ -1,3 +1,6 @@
+// Currently broken!!
+// puffin_egui has to be updated
+//
 // This example needs the puffin feature enabled to work
 // you can test this with:
 // cargo run --example puffin --features puffin


### PR DESCRIPTION
This will update egui to 0.33

will fix #37 

Currently the puffin example is broken.

I'm thinking about dropping the puffin feature as it still seems to be abandoned 

