### PR TITLE
update the rust version to 2024 and also update regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egui_logger"
 version = "0.9.0"
-edition = "2021"
+edition = "2024"
 authors = ["Jacob <RegenJacob@gmx.de>"]
 license = "MIT"
 readme = "README.md"
@@ -16,7 +16,7 @@ puffin = ["dep:puffin"]
 [dependencies]
 log = "0.4"
 egui = "0.33"
-regex = "1.11"
+regex = "1.12"
 puffin = { version = "0.19",  optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 
-pub use ui::logger_ui;
 pub use ui::LoggerUi;
+pub use ui::logger_ui;
 
 use log::SetLoggerError;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,9 @@
 use std::sync::Mutex;
 
-use egui::{text::LayoutJob, Align, Color32, FontSelection, RichText, Style};
+use egui::{Align, Color32, FontSelection, RichText, Style, text::LayoutJob};
 use regex::{Regex, RegexBuilder};
 
-use crate::{Logger, Record, LEVELS, LOGGER};
+use crate::{LEVELS, LOGGER, Logger, Record};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum TimePrecision {


### PR DESCRIPTION
As egui itself requires [rust 2024](https://github.com/emilk/egui/blob/main/Cargo.toml#L24),
It seems to be a good Idea to switch to the newer version. 