### PR TITLE
Replace the puffin crate with the profiling crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,19 +11,23 @@ categories = ["gui", "game-development", "development-tools::debugging"]
 include = ["src/*.rs", "Cargo.toml", "LICENSE"]
 
 [features]
-puffin = ["dep:puffin"]
+#puffin = ["dep:puffin"]
+#profiling = ["dep:profiling"]
 
 [dependencies]
 log = "0.4"
 egui = "0.33"
 regex = "1.11"
-puffin = { version = "0.19",  optional = true }
+profiling = "1.0"
+#profiling = { version = "1.0", features = ["profile-with-puffin"]}
 
 [dev-dependencies]
 eframe = "0.33"
 multi_log = "0.1"
 env_logger = "0.11"
 puffin_egui = { version = "0.29.0" }
+profiling = { version = "1.0", features = ["profile-with-tracy"]}
+puffin = "0.19"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }
@@ -33,4 +37,4 @@ chrono = { version = "0.4", default-features = false, features = ["alloc", "cloc
 
 [patch.crates-io]
 # It seems that puffin and puffin_egui are really outdated
-puffin_egui = { git = "https://github.com/EmbarkStudios/puffin.git", rev = "refs/pull/244/head" }
+puffin_egui = { git = "https://github.com/EmbarkStudios/puffin.git", rev = "refs/pull/267/head" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["src/*.rs", "Cargo.toml", "LICENSE"]
 [dependencies]
 log = "0.4"
 egui = "0.33"
-regex = "1.11"
+regex = "1.12"
 profiling = "1.0"
 #profiling = { version = "1.0", features = ["profile-with-puffin"]}
 

--- a/examples/puffin.rs
+++ b/examples/puffin.rs
@@ -28,8 +28,7 @@ impl eframe::App for MyApp {
         puffin::GlobalProfiler::lock().new_frame();
         puffin_egui::profiler_window(ctx);
         egui::CentralPanel::default().show(ctx, |ui| {
-            #[cfg(feature = "puffin")]
-            puffin::profile_scope!("Render UI");
+            profiling::scope!("Render UI");
             if ui.button("This produces Debug Info").clicked() {
                 log::debug!("Very verbose Debug Info")
             }
@@ -57,5 +56,6 @@ impl eframe::App for MyApp {
                 .enable_regex(true) // enables regex, default is true
                 .show(ui)
         });
+        profiling::finish_frame!();
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -248,14 +248,14 @@ impl LoggerUi {
     pub fn show(self, ui: &mut egui::Ui) {
         if let Ok(ref mut logger_ui) = self.log_ui().lock() {
             logger_ui.ui(ui);
+            profiling::finish_frame!();
         } else {
             ui.colored_label(Color32::RED, "Something went wrong loading the log");
         }
     }
 
+    #[profiling::function]
     pub(crate) fn ui(&mut self, ui: &mut egui::Ui) {
-        #[cfg(feature = "puffin")]
-        puffin::profile_scope!("render logger UI");
         let Ok(ref mut logger) = LOGGER.lock() else {
             return;
         };


### PR DESCRIPTION
# This replaces the puffin crate with profling

[proflining](https://github.com/aclysma/profiling) is an abstraction layer which does have puffin support.
It also supports Tracy (which I find quite useful) 

But somehow I can't get puffin to work in the example